### PR TITLE
Add iterator for objects, change null to error on strict

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -76,17 +76,22 @@ function evaluateOpCodes(context, opCodes) {
 
       case 'explode':
         context = context.reduce((result, each) => {
-          if (each == null) {
-            return result
+          if (Array.isArray(each)) {
+            return result.concat(each)
+          } else if (typeof each === 'object' && each != null) {
+            return result.concat(Object.values(each))
           }
 
-          if (!Array.isArray(each)) {
-            if (opCode.strict) {
-              throw new Error('Cannot iterate over ' + typeof each)
+          if (opCode.strict) {
+            let type = typeof each
+            if (each === null) {
+              // jq throws an error specifically for null, so let's
+              // distinguish that from object.
+              type = 'null'
             }
-            return result
+            throw new Error('Cannot iterate over ' + type)
           }
-          return result.concat(each)
+          return result
         }, [])
         break
 

--- a/test/execute.test.js
+++ b/test/execute.test.js
@@ -196,6 +196,34 @@ describe('create object', () => {
   })
 })
 
+describe('iterator', () => {
+  test('array', () => {
+    const input = [ 'foo', 'bar' ]
+    const script = '.[]'
+    expect(executeScript(input, script)).toEqual(['foo', 'bar'])
+  })
+  
+  test('object', () => {
+    const input = {foo: 'a', bar: 'b' }
+    const script = '.[]'
+    expect(executeScript(input, script)).toEqual(['a', 'b'])
+  })
+  
+  test('nested', () => {
+    const input = {foo: [{a: 1, b: 2}], bar: [{a: 3, b: 4}]}
+    const script = '.[].[].b'
+    expect(executeScript(input, script)).toEqual([2, 4])
+  })
+  
+  test('cannot iterate over null', () => {
+    const input = null
+    const script = '.[]'
+    expect(() =>
+      executeScript(input, script)
+    ).toThrowErrorMatchingInlineSnapshot('"Cannot iterate over null"')
+  })
+})
+
 test('nested structures', () => {
   const input = {
     foo: [


### PR DESCRIPTION
This commit mainly adds the ability to iterate over objects with the
iterator operator as described in the jq manual, in the same fashion as
arrays can be iterated over.

Additionally the handling for iterating null has changed to be more
jq-specific, treating it like other unsupported types and specifically
identifying null as "null" and not "object".