### PR TITLE
Ensure iterators in object constructors construct multiple objects

### DIFF
--- a/test/execute.test.js
+++ b/test/execute.test.js
@@ -194,6 +194,17 @@ describe('create object', () => {
       bar: 'bar',
     })
   })
+
+  test('with iterators', () => {
+    const input = { foo: [ 'a', 'b' ], bar: [ 1, 2 ] }
+    const script = '{ foo: .foo[], bar: .bar[] }'
+    expect(executeScript(input, script)).toEqual([
+      { foo: 'a', bar: 1},
+      { foo: 'a', bar: 2},
+      { foo: 'b', bar: 1},
+      { foo: 'b', bar: 2},
+    ])
+  })
 })
 
 describe('iterator', () => {
@@ -215,6 +226,35 @@ describe('iterator', () => {
     expect(executeScript(input, script)).toEqual([2, 4])
   })
   
+  test('object, nested', () => {
+    const input = {foo: [{a: 1, b: 2}, {a: 3, b: 4}], bar: [{a: 5, b: 6}, {a: 7, b: 8}]}
+    const script = '{foo: .[].[].a, bar: .[].[].b}'
+    expect(executeScript(input, script)).toEqual([
+      { foo: 1, bar: 2},
+      { foo: 1, bar: 4},
+      { foo: 1, bar: 6},
+      { foo: 1, bar: 8},
+      { foo: 3, bar: 2},
+      { foo: 3, bar: 4},
+      { foo: 3, bar: 6},
+      { foo: 3, bar: 8},
+      { foo: 5, bar: 2},
+      { foo: 5, bar: 4},
+      { foo: 5, bar: 6},
+      { foo: 5, bar: 8},
+      { foo: 7, bar: 2},
+      { foo: 7, bar: 4},
+      { foo: 7, bar: 6},
+      { foo: 7, bar: 8},
+    ])
+  })
+
+  test('should not double-promote double-nested single elment array', () => {
+    const input = [[1]]
+    const script = '{foo: .[]}'
+    expect(executeScript(input, script)).toEqual({foo: [1]})
+  })
+
   test('cannot iterate over null', () => {
     const input = null
     const script = '.[]'


### PR DESCRIPTION
This ensures that micro-jq conforms to jq's "spec" of constructing
multiple objects when a field in an object constructor produces
"multiple results".

The text in the manual is slightly ambiguous to the actual behavior
here: "multiple results" generally refers to when an iterator
operation is called in the sub-expression for a particular object field,
versus *any* result, such as an expression that simply returns an array.
Hence, while "{ foo: .[] }" being  called on "[1, 2]" would return two
objects with a key of "foo" and a value of 1 and 2 respectively,
"{ foo: . }" itself without the iterator would return a single object
with the "foo" field pointing to the array itself.

jq accomplishes this behavior via the use of backtracking, generators,
and most specifically "fork points" (see
https://github.com/stedolan/jq/wiki/Internals:-backtracking). This
approach is significantly more complex than micro-jq's at this time,
and adopting something akin to it would probably require significant
rewriting of the interpreter and the grammar internals. Ultimately,
however, in regards to where it currently matters to micro-jq, it seems
to boil down to:

* Ensure we can determine when an explode operation occurred. This
commit accomplishes this by adding an optional callback to
evaluateOpCodes. The purpose of this callback can be extended in the
future, but for now, we are using it to signal when an iterator
operation was encountered during object creation. The callback also
tracks the length of the iterated Array so that we can handle it
properly in the event of zero or single-length arrays, which may end up
getting auto-promoted by evaluateOpCodes in a way that can affect
iteration.

* Use the current behavior for object construction to instead build a
matrix of indexed value operations: a key now creates one or more
iterations of an object now with different individual values.

* Apply a simple recursive function to create the correct amount of
objects based on the product of the number of values each key holds.