### PR TITLE
Improvement for iterators

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -6,7 +6,7 @@ module.exports = function executeScript(input, script) {
   return evaluateOpCodes([input], opCodes)
 }
 
-function evaluateOpCodes(context, opCodes) {
+function evaluateOpCodes(context, opCodes, callback) {
   if (!Array.isArray(opCodes)) {
     opCodes = [opCodes]
   }
@@ -23,87 +23,31 @@ function evaluateOpCodes(context, opCodes) {
         break
 
       case 'pick':
-        context = context.reduce((result, each) => {
-          if (each != null && typeof each !== 'object') {
-            if (opCode.strict) {
-              throw new Error(`Cannot index ${typeof each} with ${opCode.key}`)
-            }
-            // Skip this value entirely
-            return result
-          }
-          let picked = each[opCode.key]
-          result.push(picked)
-          return result
-        }, [])
+        context = evaluateOpCode_pick(context, opCode)
         break
 
       case 'index':
-        context = context.reduce((result, each) => {
-          if (!Array.isArray(each)) {
-            if (opCode.strict) {
-              throw new Error('Can only index into arrays')
-            }
-            return result
-          }
-          let indexed
-          if (Math.abs(opCode.index) > each.length || opCode.index === each.length) {
-            indexed = null
-          } else if (opCode.index < 0) {
-            indexed = each.slice(opCode.index)[0]
-          } else {
-            indexed = each[opCode.index]
-          }
-          result.push(indexed)
-          return result
-        }, [])
+        context = evaluateOpCode_index(context, opCode)
         break
 
       case 'slice':
-        context = context.reduce((result, each) => {
-          if ('undefined' === typeof each.slice) {
-            if (opCode.strict) {
-              throw new Error('Cannot slice ' + typeof each)
-            }
-            return result
-          }
-          if (undefined === opCode.start && undefined === opCode.end) {
-            throw new Error('Cannot slice with no offsets')
-          }
-          result.push(each.slice(opCode.start, opCode.end))
-          return result
-        }, [])
+        context = evaluateOpCode_slice(context, opCode)
         break
 
       case 'explode':
-        context = context.reduce((result, each) => {
-          if (Array.isArray(each)) {
-            return result.concat(each)
-          } else if (typeof each === 'object' && each != null) {
-            return result.concat(Object.values(each))
-          }
-
-          if (opCode.strict) {
-            let type = typeof each
-            if (each === null) {
-              // jq throws an error specifically for null, so let's
-              // distinguish that from object.
-              type = 'null'
-            }
-            throw new Error('Cannot iterate over ' + type)
-          }
-          return result
-        }, [])
+        context = evaluateOpCode_explode(context, opCode, callback)
         break
 
       case 'create_array':
-        context = [ opCode.values.map(each => evaluateOpCodes(context, each)) ]
+        context = evaluateOpCode_create_array(context, opCode, callback)
         break
 
       case 'create_object':
-        context = [ opCode.entries.reduce((result, each) => {
-          result[each.key] = evaluateOpCodes(context, each.value)
-          return result
-        }, {}) ]
+        context = evaluateOpCode_create_object(context, opCode, callback)
+        break
+
+      case 'pipe':
+        context = evaluateOpCode_pipe(context, opCode, callback)
         break
 
       default:
@@ -112,4 +56,178 @@ function evaluateOpCodes(context, opCodes) {
   } while (opCodes.length > 0)
 
   return context.length > 1 ? context : context[0]
+}
+
+function evaluateOpCode_pick(context, opCode) {
+  return context.reduce((result, each) => {
+    if (each != null && typeof each !== 'object') {
+      if (opCode.strict) {
+        throw new Error(`Cannot index ${typeof each} with ${opCode.key}`)
+      }
+      // Skip this value entirely
+      return result
+    }
+    let picked = each[opCode.key]
+    result.push(picked)
+    return result
+  }, [])
+}
+
+function evaluateOpCode_index(context, opCode) {
+  return context.reduce((result, each) => {
+    if (!Array.isArray(each)) {
+      if (opCode.strict) {
+        throw new Error('Can only index into arrays')
+      }
+      return result
+    }
+    let indexed
+    if (Math.abs(opCode.index) > each.length || opCode.index === each.length) {
+      indexed = null
+    } else if (opCode.index < 0) {
+      indexed = each.slice(opCode.index)[0]
+    } else {
+      indexed = each[opCode.index]
+    }
+    result.push(indexed)
+    return result
+  }, [])
+}
+
+function evaluateOpCode_slice(context, opCode) {
+  return context.reduce((result, each) => {
+    if ('undefined' === typeof each.slice) {
+      if (opCode.strict) {
+        throw new Error('Cannot slice ' + typeof each)
+      }
+      return result
+    }
+    if (undefined === opCode.start && undefined === opCode.end) {
+      throw new Error('Cannot slice with no offsets')
+    }
+    result.push(each.slice(opCode.start, opCode.end))
+    return result
+  }, [])
+}
+
+function evaluateOpCode_explode(context, opCode, callback) {
+  context = context.reduce((result, each) => {
+    if (Array.isArray(each)) {
+      return result.concat(each)
+    } else if (typeof each === 'object' && each != null) {
+      return result.concat(Object.values(each))
+    }
+    if (opCode.strict) {
+      let type = typeof each
+      if (each === null) {
+        // jq throws an error specifically for null, so let's
+        // distinguish that from object.
+        type = 'null'
+      }
+      throw new Error('Cannot iterate over ' + type)
+    }
+    return result
+  }, [])
+  if (callback) {
+    callback(context.length)
+  }
+  return context
+}
+
+function evaluateOpCode_create_array(context, opCode, callback) {
+  return [ opCode.values.reduce((result, each) => { 
+    const exploder = makeExploder()
+    let values = evaluateOpCodes(context, [...each], makeExploderCb(exploder, callback))
+    if (!exploder.exploded) {
+      result.push(values)
+    } else {
+      switch (exploder.length) {
+        case 0:
+          break
+         
+        case 1:
+          result.push(values)
+          break
+
+        default:
+          result = result.concat(values)
+      }
+    }
+
+    return result
+  }, []) ]
+}
+
+function evaluateOpCode_create_object(context, opCode, callback) {
+  return evaluateOpCode_create_object_build({}, Object.entries(opCode.entries.reduce((result, each) => {
+    const exploder = makeExploder()
+    let values = evaluateOpCodes(context, [...each.value], makeExploderCb(exploder, callback))
+    if (!exploder.exploded) {
+      result[each.key] = [values]
+    } else {
+      switch (exploder.length) {
+        case 0:
+          result[each.key] = []
+          break
+        
+        case 1:
+          result[each.key] = [values]
+          break
+
+        default:
+          result[each.key] = values
+          break
+      }
+    }
+    return result
+  }, {})))
+}
+  
+function evaluateOpCode_create_object_build(current, ops) {
+  let result = []
+  let key, values
+  [key, values] = ops.shift()
+  values.forEach(value => {
+    current[key] = value
+    if (ops.length > 0) {
+      result = result.concat(evaluateOpCode_create_object_build({...current}, [...ops]))
+    } else {
+      result.push({...current})
+    }
+  })
+  return result
+}
+
+function evaluateOpCode_pipe(context, opCode, callback) {
+  const exploder = makeExploder()
+  context = evaluateOpCodes(context, [...opCode.in], makeExploderCb(exploder, callback))
+  if (!exploder.exploded) {
+    context = evaluateOpCodes([context], [...opCode.out])
+  } else {
+    switch (exploder.length) {
+      case 0:
+        context = []
+        break
+      
+      case 1:
+        context = [context]
+        break
+    }
+    context = context.map(each => evaluateOpCodes([each], [...opCode.out]))
+  }
+  return context
+}
+
+function makeExploder() {
+  return {exploded: false, length: 0}
+}
+
+function makeExploderCb(exploder, callback) {
+  return (length) => {
+    exploder.exploded = true
+    exploder.length = length
+    if (callback) {
+      callback(length)
+    }
+  }
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -143,7 +143,11 @@ function peg$parse(input, options) {
 
       peg$c0 = function(head, tail) {
           return tail.reduce(function(result, element) {
-            return result.concat(element[3])
+            return [{
+              op:  'pipe',
+              in:  result,
+              out: Array.isArray(element[3]) ? element[3] : [element[3]],
+            }]
           }, Array.isArray(head) ? head : [head])
         },
       peg$c1 = peg$otherExpectation("whitespace"),

--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -19,7 +19,11 @@ Script
 Expression
   = head:Operation tail:(_ Pipe* _ Operation)* {
     return tail.reduce(function(result, element) {
-      return result.concat(element[3])
+      return [{
+        op:  'pipe',
+        in:  result,
+        out: Array.isArray(element[3]) ? element[3] : [element[3]],
+      }]
     }, Array.isArray(head) ? head : [head])
   }
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -265,14 +265,93 @@ test('pipe commands together', () => {
   expect(parse('.foo | .bar')).toMatchInlineSnapshot(`
 Array [
   Object {
-    "key": "foo",
-    "op": "pick",
-    "strict": true,
+    "in": Array [
+      Object {
+        "key": "foo",
+        "op": "pick",
+        "strict": true,
+      },
+    ],
+    "op": "pipe",
+    "out": Array [
+      Object {
+        "key": "bar",
+        "op": "pick",
+        "strict": true,
+      },
+    ],
   },
+]
+`)
+})
+
+test('multiple pipe', () => {
+  expect(parse('.foo | .bar | .baz')).toMatchInlineSnapshot(`
+Array [
   Object {
-    "key": "bar",
-    "op": "pick",
-    "strict": true,
+    "in": Array [
+      Object {
+        "in": Array [
+          Object {
+            "key": "foo",
+            "op": "pick",
+            "strict": true,
+          },
+        ],
+        "op": "pipe",
+        "out": Array [
+          Object {
+            "key": "bar",
+            "op": "pick",
+            "strict": true,
+          },
+        ],
+      },
+    ],
+    "op": "pipe",
+    "out": Array [
+      Object {
+        "key": "baz",
+        "op": "pick",
+        "strict": true,
+      },
+    ],
+  },
+]
+`)
+})
+
+test('pipe into create object', () => {
+  expect(parse('.[] | {foo: .bar}')).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "in": Array [
+      Object {
+        "op": "current_context",
+      },
+      Object {
+        "op": "explode",
+        "strict": true,
+      },
+    ],
+    "op": "pipe",
+    "out": Array [
+      Object {
+        "entries": Array [
+          Object {
+            "key": "foo",
+            "value": Array [
+              Object {
+                "key": "bar",
+                "op": "pick",
+                "strict": true,
+              },
+            ],
+          },
+        ],
+        "op": "create_object",
+      },
+    ],
   },
 ]
 `)


### PR DESCRIPTION
This ensures that micro-jq conforms to jq's "spec" of constructing
multiple objects when a field in an object constructor produces
"multiple results".

The text in the manual is slightly ambiguous to the actual behavior
here: "multiple results" generally refers to when an iterator
operation is called in the sub-expression for a particular object field,
versus *any* result, such as an expression that simply returns an array.
Hence, while "{ foo: .[] }" being  called on "[1, 2]" would return two
objects with a key of "foo" and a value of 1 and 2 respectively,
"{ foo: . }" itself without the iterator would return a single object
with the "foo" field pointing to the array itself. This behavior carries
over to any downstream expression as well, such as in the event of a
pipe.

jq accomplishes this behavior via the use of backtracking, generators,
and most specifically "fork points" (see
https://github.com/stedolan/jq/wiki/Internals:-backtracking). This
approach is significantly more complex than micro-jq's at this time,
and adopting something akin to it would probably require significant
rewriting of the interpreter and the grammar internals. Ultimately,
however, in regards to where it currently matters to micro-jq, it seems
to boil down to:

* Ensure we can determine when an explode operation occurred. This
commit accomplishes this by adding an optional callback to
evaluateOpCodes. The purpose of this callback can be extended in the
future, but for now, we are using it to signal when an iterator
operation was encountered. The callback also tracks the length of the
iterated Array so that we can handle it properly in the event of zero or
single-length arrays, which may end up getting auto-promoted by
evaluateOpCodes in a way that can affect iteration.

* Use the current behavior for object construction to instead build a
matrix of indexed value operations: a key now creates one or more
iterations of an object now with different individual values. Objects
are then created by applying a simple recursive function to create the
correct amount of objects based on the product of the number of values
each key holds.

* Since pipes are also affected by this, some updates to the parser have
been necessary to explicitly distinguish pipes as an operation. On the
interpreter side we now apply the sub-expression on the LHS of the pipe,
detect if an iterator operation was encountered, and if so, process the
RHS on each element in the result individually.

Since this increases the LOC of the interpreter significantly, this
commit also breaks up the eval operation into several sub-functions,
generally one for each operation.