### PR TITLE
Don't hand off exploder callback during array creation

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -39,7 +39,7 @@ function evaluateOpCodes(context, opCodes, callback) {
         break
 
       case 'create_array':
-        context = evaluateOpCode_create_array(context, opCode, callback)
+        context = evaluateOpCode_create_array(context, opCode)
         break
 
       case 'create_object':
@@ -134,11 +134,15 @@ function evaluateOpCode_explode(context, opCode, callback) {
   return context
 }
 
-function evaluateOpCode_create_array(context, opCode, callback) {
+function evaluateOpCode_create_array(context, opCode) {
   return [
     opCode.values.reduce((result, each) => {
       const exploder = makeExploder()
-      let values = evaluateOpCodes(context, [...each], makeExploderCb(exploder, callback))
+      // Array creation terminates an explode chain - all generated
+      // results will get collected in the singular array. As such,
+      // no parent is called to makeExploderCb, and none is taken by
+      // this function.
+      let values = evaluateOpCodes(context, [...each], makeExploderCb(exploder))
       if (!exploder.exploded) {
         result.push(values)
       } else {

--- a/test/execute.test.js
+++ b/test/execute.test.js
@@ -311,4 +311,18 @@ describe('nested structures', () => {
       { name: 'bar-b', value: 4 },
     ])
   })
+
+  test('#3', () => {
+    const input = {
+      data: {
+        foo: {
+          entries: [{ name: 'foo-a', a: { b: { c: { d: [{ e: 1 }, { e: 2 }] } } } }],
+        },
+      },
+    }
+
+    expect(
+      executeScript(input, '[.data[].entries[] | {name: .name, values: [ .a.b.c.d[] | .e ]}]')
+    ).toEqual([{ name: 'foo-a', values: [1, 2] }])
+  })
 })


### PR DESCRIPTION
This fixes array creation so that the exploder callback chain is broken
during the operation.

The reason for this is that while multiple results are generated during
object creation, all results from an expression in array creation are
concatenated, with the result being a single array instance. Hence, any
parent operations should just see a single generated value and should
not iterate over its results.