### PR TITLE
Handle unknown object key lookups

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -67,7 +67,10 @@ function evaluateOpCode_pick(context, opCode) {
       // Skip this value entirely
       return result
     }
-    let picked = each[opCode.key]
+    let picked = null
+    if (each && each[opCode.key]) {
+      picked = each[opCode.key]
+    }
     result.push(picked)
     return result
   }, [])

--- a/test/execute.test.js
+++ b/test/execute.test.js
@@ -16,6 +16,12 @@ describe('literals', () => {
 })
 
 describe('pick values', () => {
+  test('missing', () => {
+    const input = {}
+    const script = '.foo'
+    expect(executeScript(input, script)).toEqual(null)
+  })
+
   test('one deep', () => {
     const input = { foo: 'bar' }
     const script = '.foo'
@@ -299,6 +305,7 @@ describe('nested structures', () => {
           entries: [
             { name: 'bar-a', a: { b: { c: { d: 3 } } } },
             { name: 'bar-b', a: { b: { c: { d: 4 } } } },
+            { name: 'bar-c', a: {} },
           ],
         },
       },
@@ -309,6 +316,7 @@ describe('nested structures', () => {
       { name: 'foo-b', value: 2 },
       { name: 'bar-a', value: 3 },
       { name: 'bar-b', value: 4 },
+      { name: 'bar-c', value: null },
     ])
   })
 


### PR DESCRIPTION
This handles unknown object key lookups by defaulting said keys to null,
which is behavior similar to jq itself.

The previous behavior would generally either yield undefined values or
cause exceptions due to lookups on an undefined type.