### PR TITLE
feat: extend jq filter language support

### DIFF
--- a/src/execute.ts
+++ b/src/execute.ts
@@ -2,17 +2,21 @@ import { evaluateOpCode_function } from './opcode-function'
 // @ts-ignore
 import { parse } from './parser'
 import {
+  ComparisonOperator,
   Context,
   Exploder,
   ExploderCallback,
   JSONValue,
   OpCode,
+  OpComparison,
   OpCreateArray,
   OpCreateObject,
   OpExplode,
   OpIndex,
+  OpLogical,
   OpPick,
   OpPipe,
+  OpSelect,
   OpSlice,
 } from './types'
 
@@ -58,6 +62,14 @@ function evaluateOpCodes(
         context = evaluateOpCode_explode(context, opCode, callback)
         break
 
+      case 'recursive_descent':
+        context = evaluateOpCode_recursive_descent(context, callback)
+        break
+
+      case 'to_entries':
+        context = evaluateOpCode_to_entries(context, callback)
+        break
+
       case 'create_array':
         context = evaluateOpCode_create_array(context, opCode)
         break
@@ -72,6 +84,19 @@ function evaluateOpCodes(
 
       case 'function':
         context = evaluateOpCode_function(context, opCode)
+        break
+
+      case 'comparison':
+        context = evaluateOpCode_comparison(context, opCode)
+        break
+
+      case 'and':
+      case 'or':
+        context = evaluateOpCode_logical(context, opCode)
+        break
+
+      case 'select':
+        context = evaluateOpCode_select(context, opCode)
         break
 
       default:
@@ -163,6 +188,95 @@ function evaluateOpCode_explode(
     callback(context.length)
   }
   return context
+}
+
+function evaluateOpCode_recursive_descent(context: Context, callback?: ExploderCallback): Context {
+  const result: Context = []
+
+  function walk(value: JSONValue) {
+    result.push(value)
+    if (Array.isArray(value)) {
+      value.forEach(walk)
+    } else if (typeof value === 'object' && value !== null) {
+      Object.values(value).forEach(walk)
+    }
+  }
+
+  context.forEach(walk)
+
+  if (callback) {
+    callback(result.length)
+  }
+  return result
+}
+
+function evaluateOpCode_to_entries(context: Context, callback?: ExploderCallback): Context {
+  const result: Context = []
+  for (const each of context) {
+    if (Array.isArray(each)) {
+      for (let i = 0; i < (each as JSONValue[]).length; i++) {
+        result.push({ key: i as unknown as JSONValue, value: (each as JSONValue[])[i] })
+      }
+    } else if (typeof each === 'object' && each !== null) {
+      for (const [k, v] of Object.entries(each as Record<string, JSONValue>)) {
+        result.push({ key: k as JSONValue, value: v })
+      }
+    } else {
+      throw new Error(`Cannot get entries of ${typeof each}`)
+    }
+  }
+  if (callback) callback(result.length)
+  return result
+}
+
+function evaluateOpCode_comparison(context: Context, opCode: OpComparison): Context {
+  return context.map((each) => {
+    const left = evaluateOpCodes([each], [...opCode.left])
+    const right = evaluateOpCodes([each], [...opCode.right])
+    return compareValues(left, right, opCode.operator)
+  })
+}
+
+function compareValues(left: JSONValue, right: JSONValue, operator: ComparisonOperator): boolean {
+  switch (operator) {
+    case '==':
+      return deepEqual(left, right)
+    case '!=':
+      return !deepEqual(left, right)
+    case '<':
+      return (left as number) < (right as number)
+    case '>':
+      return (left as number) > (right as number)
+    case '<=':
+      return (left as number) <= (right as number)
+    case '>=':
+      return (left as number) >= (right as number)
+  }
+}
+
+function deepEqual(a: JSONValue, b: JSONValue): boolean {
+  if (a === b) return true
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+function evaluateOpCode_logical(context: Context, opCode: OpLogical): Context {
+  return context.map((each) => {
+    const left = evaluateOpCodes([each], [...opCode.left])
+    const right = evaluateOpCodes([each], [...opCode.right])
+    if (opCode.op === 'and') return Boolean(left) && Boolean(right)
+    return Boolean(left) || Boolean(right)
+  })
+}
+
+function evaluateOpCode_select(context: Context, opCode: OpSelect): Context {
+  return context.filter((each) => {
+    try {
+      const result = evaluateOpCodes([each], [...opCode.condition])
+      return result !== null && result !== false && result !== undefined
+    } catch {
+      return false
+    }
+  })
 }
 
 function evaluateOpCode_create_array(context: Context, opCode: OpCreateArray): Context {
@@ -260,7 +374,10 @@ function evaluateOpCode_pipe(
   callback?: ExploderCallback
 ): Context {
   const exploder = makeExploder()
-  let result = evaluateOpCodes(context, [...opCode.in], makeExploderCb(exploder, callback))
+  // Use a non-propagating local callback so that nested pipe explosions (e.g. from
+  // to_entries inside a deeper pipe) don't prematurely signal the parent with a stale count.
+  // Instead, we signal the parent ourselves after all right-side filtering is done.
+  let result = evaluateOpCodes(context, [...opCode.in], makeExploderCb(exploder))
   if (!exploder.exploded) {
     result = evaluateOpCodes([result], [...opCode.out])
   } else {
@@ -278,10 +395,15 @@ function evaluateOpCode_pipe(
         explodedResult = result as JSONValue[]
         break
     }
-    result =
-      explodedResult == null
-        ? null
-        : explodedResult.map((each) => evaluateOpCodes([each], [...opCode.out]))
+    // Apply right side to each exploded value; select() returns undefined for filtered items
+    const pipeResults: JSONValue[] = []
+    for (const each of explodedResult ?? []) {
+      const r = evaluateOpCodes([each], [...opCode.out])
+      if (r !== undefined) pipeResults.push(r)
+    }
+    result = pipeResults
+    // Signal parent with the actual post-filter count
+    if (callback) callback(pipeResults.length)
   }
   return Array.isArray(result) ? result : [result]
 }

--- a/src/opcode-function.ts
+++ b/src/opcode-function.ts
@@ -1,4 +1,4 @@
-import { Context, NoArgFunctioName, OpFunction, StringArgFunctionName } from './types'
+import { Context, JSONValue, NoArgFunctioName, OpFunction, StringArgFunctionName } from './types'
 
 export function evaluateOpCode_function(context: Context, { name, value }: OpFunction): Context {
   const result: Context = []
@@ -32,50 +32,75 @@ export function evaluateOpCode_function(context: Context, { name, value }: OpFun
   return result
 }
 
-const noArgCallbacks = {
-  ltrim(each: Context[number]): string {
+const noArgCallbacks: Record<NoArgFunctioName, (each: JSONValue) => JSONValue> = {
+  ltrim(each) {
     if (typeof each !== 'string') throw new Error(`Cannot ltrim ${typeof each}`)
     return each.trimStart()
   },
-  rtrim(each: Context[number]): string {
+  rtrim(each) {
     if (typeof each !== 'string') throw new Error(`Cannot rtrim ${typeof each}`)
     return each.trimEnd()
   },
-  trim(each: Context[number]): string {
+  trim(each) {
     if (typeof each !== 'string') throw new Error(`Cannot trim ${typeof each}`)
     return each.trim()
   },
-} as const
+  not(each) {
+    return !each
+  },
+  keys(each) {
+    if (Array.isArray(each)) return each.map((_, i) => i)
+    if (typeof each === 'object' && each !== null)
+      return Object.keys(each as Record<string, JSONValue>).sort()
+    throw new Error(`Cannot get keys of ${typeof each}`)
+  },
+  from_entries(each) {
+    if (!Array.isArray(each)) throw new Error('from_entries input must be an array')
+    const result: Record<string, JSONValue> = {}
+    for (const entry of each) {
+      if (typeof entry !== 'object' || Array.isArray(entry) || entry === null) {
+        throw new Error('from_entries entry must be an object')
+      }
+      const e = entry as Record<string, JSONValue>
+      const k = e.key ?? e.name
+      if (k === undefined || k === null) throw new Error('from_entries entry must have key or name')
+      result[String(k)] = e.value as JSONValue
+    }
+    return result
+  },
+}
 
-const stringArgCallbacks = {
-  startswith<Value extends string>(
-    each: Context[number],
-    value: Value
-  ): each is `${Value}${string}` {
+const stringArgCallbacks: Record<
+  StringArgFunctionName,
+  (each: JSONValue, value: string) => JSONValue
+> = {
+  startswith(each, value) {
     if (typeof each !== 'string') throw new Error(`Cannot startswith ${typeof each}`)
     return each.startsWith(value)
   },
 
-  endswith<Value extends string>(each: Context[number], value: Value): each is `${string}${Value}` {
+  endswith(each, value) {
     if (typeof each !== 'string') throw new Error(`Cannot endswith ${typeof each}`)
     return each.endsWith(value)
   },
 
-  ltrimstr(each: Context[number], value: string): string {
-    return stringArgCallbacks.startswith(each, value) ? each.slice(value.length) : value
+  ltrimstr(each, value) {
+    if (typeof each !== 'string') throw new Error(`Cannot ltrimstr ${typeof each}`)
+    return each.startsWith(value) ? each.slice(value.length) : each
   },
 
-  rtrimstr(each: Context[number], value: string): string {
-    return stringArgCallbacks.endswith(each, value) ? each.slice(0, 0 - value.length) : value
+  rtrimstr(each, value) {
+    if (typeof each !== 'string') throw new Error(`Cannot rtrimstr ${typeof each}`)
+    return each.endsWith(value) ? each.slice(0, -value.length) : each
   },
 
-  split(each: Context[number], value: string): string[] {
+  split(each, value) {
     if (typeof each !== 'string') throw new Error(`Cannot split ${typeof each}`)
     return each.split(value)
   },
 
-  join(each: Context[number], value: string): string {
+  join(each, value) {
     if (!Array.isArray(each)) throw new Error(`Cannot join ${typeof each}`)
     return each.join(value)
   },
-} as const
+}

--- a/src/opcode-function.ts
+++ b/src/opcode-function.ts
@@ -62,9 +62,10 @@ const noArgCallbacks: Record<NoArgFunctioName, (each: JSONValue) => JSONValue> =
         throw new Error('from_entries entry must be an object')
       }
       const e = entry as Record<string, JSONValue>
-      const k = e.key ?? e.name
+      const k = e.key ?? e.Key ?? e.name ?? e.Name
       if (k === undefined || k === null) throw new Error('from_entries entry must have key or name')
-      result[String(k)] = e.value as JSONValue
+      const v = 'value' in e ? e.value : e.Value
+      result[String(k)] = v as JSONValue
     }
     return result
   },

--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -17,7 +17,7 @@ Script
   = Expression
 
 Expression
-  = head:Operation tail:(_ Pipe* _ Operation)* {
+  = head:OrExpr tail:(_ Pipe* _ OrExpr)* {
     return tail.reduce(function(result, element) {
       return [{
         op:  'pipe',
@@ -26,6 +26,51 @@ Expression
       }]
     }, Array.isArray(head) ? head : [head])
   }
+
+OrExpr
+  = head:AndExpr tail:(_ 'or' !IdentifierPart _ AndExpr)* {
+    if (tail.length === 0) return head
+    return tail.reduce(function(acc, element) {
+      var right = element[4]
+      return {
+        op: 'or',
+        left: Array.isArray(acc) ? acc : [acc],
+        right: Array.isArray(right) ? right : [right],
+      }
+    }, head)
+  }
+
+AndExpr
+  = head:Comparison tail:(_ 'and' !IdentifierPart _ Comparison)* {
+    if (tail.length === 0) return head
+    return tail.reduce(function(acc, element) {
+      var right = element[4]
+      return {
+        op: 'and',
+        left: Array.isArray(acc) ? acc : [acc],
+        right: Array.isArray(right) ? right : [right],
+      }
+    }, head)
+  }
+
+Comparison
+  = left:Operation _ op:ComparisonOp _ right:Operation {
+    return {
+      op: 'comparison',
+      operator: op,
+      left: Array.isArray(left) ? left : [left],
+      right: Array.isArray(right) ? right : [right],
+    }
+  }
+  / Operation
+
+ComparisonOp
+  = '=='
+  / '!='
+  / '<='
+  / '>='
+  / '<'
+  / '>'
 
 _ "whitespace"
   = [ \t\n\r]*
@@ -40,12 +85,33 @@ Traversal
   = Index
   / Slice
   / Explode
+  / RecursiveDescent
   / Pick
   / Context
 
+RecursiveDescent
+  = ".." {
+    return { op: 'recursive_descent' }
+  }
+
 Functions
-  = StringArgFunctions
+  = SelectFunction
+  / ToEntriesFunction
+  / StringArgFunctions
   / NoArgFunctions
+
+SelectFunction
+  = 'select' _ '(' _ expr:Expression _ ')' {
+    return {
+      op: 'select',
+      condition: Array.isArray(expr) ? expr : [expr],
+    }
+  }
+
+ToEntriesFunction
+  = 'to_entries' _ {
+    return { op: 'to_entries' }
+  }
 
 Index
   = "[" _ index:Number _ "]" strict:"?"? {
@@ -106,9 +172,12 @@ NoArgFunctions
   }
 
 NoArgFunctionsNames
-  = 'trim'
+  = 'from_entries'
+  / 'keys'
+  / 'trim'
   / 'ltrim'
   / 'rtrim'
+  / 'not'
 
 StringArgFunctions
   = name:StringArgFunctionNames _ "(" _ value:String _ ")" {

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,34 @@ export interface OpSlice {
   strict: boolean
 }
 
+export type ComparisonOperator = '==' | '!=' | '<' | '>' | '<=' | '>='
+
+export interface OpComparison {
+  op: 'comparison'
+  operator: ComparisonOperator
+  left: OpCode[]
+  right: OpCode[]
+}
+
+export interface OpLogical {
+  op: 'and' | 'or'
+  left: OpCode[]
+  right: OpCode[]
+}
+
+export interface OpSelect {
+  op: 'select'
+  condition: OpCode[]
+}
+
+export interface OpRecursiveDescent {
+  op: 'recursive_descent'
+}
+
+export interface OpToEntries {
+  op: 'to_entries'
+}
+
 export type StringArgFunctionName =
   | 'startswith'
   | 'endswith'
@@ -66,7 +94,7 @@ export type StringArgFunctionName =
   | 'split'
   | 'join'
 
-export type NoArgFunctioName = 'trim' | 'ltrim' | 'rtrim'
+export type NoArgFunctioName = 'trim' | 'ltrim' | 'rtrim' | 'keys' | 'from_entries' | 'not'
 
 export type AnyArgFunctionName = StringArgFunctionName | NoArgFunctioName
 
@@ -83,6 +111,11 @@ export interface OpStringArgFunction<Name extends StringArgFunctionName = String
 }
 
 export type OpCode =
+  | OpComparison
+  | OpLogical
+  | OpSelect
+  | OpRecursiveDescent
+  | OpToEntries
   | OpCreateArray
   | OpCreateObject
   | OpCurrentContext

--- a/test/execute.test.ts
+++ b/test/execute.test.ts
@@ -390,3 +390,251 @@ describe('nested structures', () => {
     ).toEqual([{ name: 'foo-a', values: [1, 2] }])
   })
 })
+
+describe('comparison operators', () => {
+  test('== on equal values', () => {
+    expect(executeScript({ type: 'keyword' }, '.type == "keyword"')).toEqual(true)
+  })
+
+  test('== on unequal values', () => {
+    expect(executeScript({ type: 'text' }, '.type == "keyword"')).toEqual(false)
+  })
+
+  test('!= on unequal values', () => {
+    expect(executeScript({ type: 'text' }, '.type != "keyword"')).toEqual(true)
+  })
+
+  test('!= on equal values', () => {
+    expect(executeScript({ type: 'keyword' }, '.type != "keyword"')).toEqual(false)
+  })
+
+  test('< on numbers', () => {
+    expect(executeScript({ n: 3 }, '.n < 5')).toEqual(true)
+    expect(executeScript({ n: 5 }, '.n < 5')).toEqual(false)
+  })
+
+  test('> on numbers', () => {
+    expect(executeScript({ n: 6 }, '.n > 5')).toEqual(true)
+    expect(executeScript({ n: 4 }, '.n > 5')).toEqual(false)
+  })
+
+  test('<= on numbers', () => {
+    expect(executeScript({ n: 5 }, '.n <= 5')).toEqual(true)
+    expect(executeScript({ n: 6 }, '.n <= 5')).toEqual(false)
+  })
+
+  test('>= on numbers', () => {
+    expect(executeScript({ n: 5 }, '.n >= 5')).toEqual(true)
+    expect(executeScript({ n: 4 }, '.n >= 5')).toEqual(false)
+  })
+
+  test('== on null', () => {
+    expect(executeScript({ a: null }, '.a == null')).toEqual(true)
+  })
+
+  test('== on nested values', () => {
+    expect(executeScript({ a: { b: 'foo' } }, '.a.b == "foo"')).toEqual(true)
+  })
+})
+
+describe('logical operators', () => {
+  test('and — both true', () => {
+    expect(executeScript({ a: 1, b: 2 }, '.a == 1 and .b == 2')).toEqual(true)
+  })
+
+  test('and — one false', () => {
+    expect(executeScript({ a: 1, b: 3 }, '.a == 1 and .b == 2')).toEqual(false)
+  })
+
+  test('or — one true', () => {
+    expect(executeScript({ type: 'text' }, '.type == "keyword" or .type == "text"')).toEqual(true)
+  })
+
+  test('or — both false', () => {
+    expect(executeScript({ type: 'date' }, '.type == "keyword" or .type == "text"')).toEqual(false)
+  })
+
+  test('chained and', () => {
+    expect(executeScript({ a: 1, b: 2, c: 3 }, '.a == 1 and .b == 2 and .c == 3')).toEqual(true)
+    expect(executeScript({ a: 1, b: 2, c: 4 }, '.a == 1 and .b == 2 and .c == 3')).toEqual(false)
+  })
+})
+
+describe('not', () => {
+  test('negates false', () => {
+    expect(executeScript(false, 'not')).toEqual(true)
+  })
+
+  test('negates true', () => {
+    expect(executeScript(true, 'not')).toEqual(false)
+  })
+
+  test('negates null', () => {
+    expect(executeScript(null, 'not')).toEqual(true)
+  })
+
+  test('via pipe', () => {
+    expect(executeScript({ active: false }, '.active | not')).toEqual(true)
+  })
+})
+
+describe('select', () => {
+  test('keeps matching elements', () => {
+    expect(executeScript([1, 2, 3, 4], '.[] | select(. > 2)')).toEqual([3, 4])
+  })
+
+  test('drops non-matching elements', () => {
+    expect(executeScript([1, 2, 3], '.[] | select(. == 99)')).toEqual(undefined)
+  })
+
+  test('with string comparison', () => {
+    const input = [{ type: 'keyword' }, { type: 'text' }, { type: 'keyword' }]
+    expect(executeScript(input, '.[] | select(.type == "keyword") | .type')).toEqual([
+      'keyword',
+      'keyword',
+    ])
+  })
+
+  test('with != comparison', () => {
+    const input = [{ type: 'keyword' }, { type: 'text' }]
+    expect(executeScript(input, '.[] | select(.type != "keyword") | .type')).toEqual('text')
+  })
+
+  test('with and condition', () => {
+    const input = [
+      { type: 'keyword', active: true },
+      { type: 'keyword', active: false },
+      { type: 'text', active: true },
+    ]
+    expect(
+      executeScript(input, '.[] | select(.type == "keyword" and .active == true)')
+    ).toEqual({ type: 'keyword', active: true })
+  })
+
+  test('with or condition', () => {
+    const input = [{ type: 'date' }, { type: 'keyword' }, { type: 'text' }]
+    expect(
+      executeScript(input, '.[] | select(.type == "keyword" or .type == "text") | .type')
+    ).toEqual(['keyword', 'text'])
+  })
+
+  test('errors suppressed — non-matching type is silently dropped', () => {
+    const input = [{ type: 'keyword' }, 'not-an-object']
+    expect(executeScript(input, '.[] | select(.type == "keyword") | .type')).toEqual('keyword')
+  })
+})
+
+describe('keys', () => {
+  test('returns sorted object keys', () => {
+    expect(executeScript({ b: 2, a: 1, c: 3 }, 'keys')).toEqual(['a', 'b', 'c'])
+  })
+
+  test('returns indices for arrays', () => {
+    expect(executeScript(['x', 'y', 'z'], 'keys')).toEqual([0, 1, 2])
+  })
+
+  test('on nested object', () => {
+    expect(executeScript({ foo: { b: 1, a: 2 } }, '.foo | keys')).toEqual(['a', 'b'])
+  })
+
+  test('throws on non-object', () => {
+    expect(() => executeScript(42, 'keys')).toThrow()
+  })
+})
+
+describe('to_entries', () => {
+  test('converts object to key/value pairs', () => {
+    expect(executeScript({ a: 1, b: 2 }, '[to_entries]')).toEqual([
+      { key: 'a', value: 1 },
+      { key: 'b', value: 2 },
+    ])
+  })
+
+  test('converts array to index/value pairs', () => {
+    expect(executeScript(['x', 'y'], '[to_entries]')).toEqual([
+      { key: 0, value: 'x' },
+      { key: 1, value: 'y' },
+    ])
+  })
+
+  test('pipes each entry individually', () => {
+    expect(executeScript({ a: 1, b: 2 }, 'to_entries | .key')).toEqual(['a', 'b'])
+  })
+
+  test('select on entries — filter by value', () => {
+    const input = { a: 'keyword', b: 'text', c: 'keyword' }
+    expect(executeScript(input, 'to_entries | select(.value == "keyword") | .key')).toEqual([
+      'a',
+      'c',
+    ])
+  })
+
+  test('primary use case — find index names by mapping type', () => {
+    const mappings = {
+      'index-1': { mappings: { properties: { status: { type: 'keyword' } } } },
+      'index-2': { mappings: { properties: { status: { type: 'text' } } } },
+      'index-3': { mappings: { properties: { status: { type: 'keyword' } } } },
+    }
+    expect(
+      executeScript(
+        mappings,
+        'to_entries | select(.value.mappings.properties.status.type != "keyword") | .key'
+      )
+    ).toEqual('index-2')
+  })
+
+  test('primary use case — multiple matches', () => {
+    const mappings = {
+      'index-1': { mappings: { properties: { status: { type: 'text' } } } },
+      'index-2': { mappings: { properties: { status: { type: 'text' } } } },
+    }
+    expect(
+      executeScript(
+        mappings,
+        'to_entries | select(.value.mappings.properties.status.type != "keyword") | .key'
+      )
+    ).toEqual(['index-1', 'index-2'])
+  })
+})
+
+describe('from_entries', () => {
+  test('converts key/value pairs back to object', () => {
+    expect(executeScript([{ key: 'a', value: 1 }, { key: 'b', value: 2 }], 'from_entries')).toEqual(
+      { a: 1, b: 2 }
+    )
+  })
+
+  test('accepts name instead of key', () => {
+    expect(executeScript([{ name: 'x', value: 42 }], 'from_entries')).toEqual({ x: 42 })
+  })
+
+  test('round-trips with to_entries', () => {
+    const input = { a: 1, b: 2 }
+    expect(executeScript(input, '[to_entries] | from_entries')).toEqual(input)
+  })
+
+  test('throws on non-array input', () => {
+    expect(() => executeScript({ a: 1 }, 'from_entries')).toThrow()
+  })
+})
+
+describe('recursive descent (..)', () => {
+  test('visits all nodes depth-first and collects optional field', () => {
+    const input = { a: { type: 'keyword' }, b: { c: { type: 'text' } } }
+    // root has no .type → null; {type:'keyword'} → 'keyword'; 'keyword' string → skipped;
+    // {c:{...}} has no .type → null; {type:'text'} → 'text'; 'text' string → skipped
+    expect(executeScript(input, '.. | .type?')).toEqual([null, 'keyword', null, 'text'])
+  })
+
+  test('works on arrays — array itself is skipped by optional pick', () => {
+    const input = [{ type: 'keyword' }, { type: 'text' }]
+    // the array itself has no .type (arrays skipped in non-strict); objects yield their .type
+    expect(executeScript(input, '.. | .type?')).toEqual(['keyword', 'text'])
+  })
+
+  test('collects all values at any depth using array construction', () => {
+    const input = { a: { b: { type: 'date' } }, c: { type: 'keyword' } }
+    const result = executeScript(input, '[.. | .type?]') as string[]
+    expect(result.filter((v) => v !== null)).toEqual(['date', 'keyword'])
+  })
+})

--- a/test/execute.test.ts
+++ b/test/execute.test.ts
@@ -428,8 +428,49 @@ describe('comparison operators', () => {
     expect(executeScript({ n: 4 }, '.n >= 5')).toEqual(false)
   })
 
+  test('< on strings (lexicographic)', () => {
+    expect(executeScript({ s: 'apple' }, '.s < "banana"')).toEqual(true)
+    expect(executeScript({ s: 'zebra' }, '.s < "banana"')).toEqual(false)
+  })
+
+  test('> on strings (lexicographic)', () => {
+    expect(executeScript({ s: 'zebra' }, '.s > "apple"')).toEqual(true)
+    expect(executeScript({ s: 'apple' }, '.s > "zebra"')).toEqual(false)
+  })
+
+  test('<= on strings', () => {
+    expect(executeScript({ s: 'apple' }, '.s <= "apple"')).toEqual(true)
+    expect(executeScript({ s: 'banana' }, '.s <= "apple"')).toEqual(false)
+  })
+
+  test('>= on strings', () => {
+    expect(executeScript({ s: 'banana' }, '.s >= "apple"')).toEqual(true)
+    expect(executeScript({ s: 'apple' }, '.s >= "banana"')).toEqual(false)
+  })
+
+  test('== on numbers', () => {
+    expect(executeScript({ n: 42 }, '.n == 42')).toEqual(true)
+    expect(executeScript({ n: 42 }, '.n == 43')).toEqual(false)
+  })
+
+  test('== on booleans', () => {
+    expect(executeScript({ active: true }, '.active == true')).toEqual(true)
+    expect(executeScript({ active: false }, '.active == true')).toEqual(false)
+  })
+
   test('== on null', () => {
     expect(executeScript({ a: null }, '.a == null')).toEqual(true)
+    expect(executeScript({ a: 'something' }, '.a == null')).toEqual(false)
+  })
+
+  test('!= on numbers', () => {
+    expect(executeScript({ n: 5 }, '.n != 3')).toEqual(true)
+    expect(executeScript({ n: 3 }, '.n != 3')).toEqual(false)
+  })
+
+  test('!= on booleans', () => {
+    expect(executeScript({ active: false }, '.active != true')).toEqual(true)
+    expect(executeScript({ active: true }, '.active != true')).toEqual(false)
   })
 
   test('== on nested values', () => {
@@ -606,6 +647,14 @@ describe('from_entries', () => {
 
   test('accepts name instead of key', () => {
     expect(executeScript([{ name: 'x', value: 42 }], 'from_entries')).toEqual({ x: 42 })
+  })
+
+  test('accepts mixed-case Key and Value', () => {
+    expect(executeScript([{ Key: 'a', Value: 1 }], 'from_entries')).toEqual({ a: 1 })
+  })
+
+  test('accepts mixed-case Name and Value', () => {
+    expect(executeScript([{ Name: 'b', Value: 2 }], 'from_entries')).toEqual({ b: 2 })
   })
 
   test('round-trips with to_entries', () => {


### PR DESCRIPTION
We are in the process of deprecating `API Console` in cloud-ui and replacing it with `OneConsole` which is kibanas very own devtools console. One very important feature we needed to bring to kibanas console in order to achieve feature parity, was output filtering. While working on that it was brought up to us that there are some features that would be great to have, and since we rely on micro-jq for these I thought of opening a small PR to add the things that were required/asked.

- **select(expr):** filter pipeline values by a condition
- **Comparison operators:**  ==, !=, <, >, <=, >=
- **and / or:** compound conditions in select
- **not:**  negate a boolean
- **to_entries:**  explode an object into {key, value} pairs (streaming, pipeable)
- **keys:** sorted array of object keys
- **from_entries:** inverse of to_entries