### PR TITLE
fix: correct TypeScript declaration metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [`2.0.2`](https://github.com/elastic/micro-jq/tree/v2.0.2)
+
+* Fix package metadata for ESM imports and TypeScript declarations
+
 ## [`2.0.1`](https://github.com/elastic/micro-jq/tree/v2.0.1)
 
 * Update dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/micro-jq",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/micro-jq",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "bin": {
         "micro-jq": "dist/cjs/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@elastic/micro-jq",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Small implementation of jq",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
+  "module": "./dist/esm/index.mjs",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "types": "./dist/esm/index.d.mts",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },
@@ -24,7 +24,7 @@
     "url": "https://github.com/elastic/micro-jq"
   },
   "bin": "./dist/cjs/cli.js",
-  "types": "./dist/esm/index.d.ts",
+  "types": "./dist/esm/index.d.mts",
   "scripts": {
     "build": "peggy --plugin ts-pegjs --cache -o ./src/parser.ts ./src/parser.pegjs && tsup",
     "lint": "eslint --cache src test",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
     entry: { index: 'src/index.ts' },
     format: ['esm'],
     outDir: 'dist/esm',
-    outExtension: () => ({ js: '.js' }),
+    outExtension: () => ({ js: '.mjs' }),
     dts: true,
     clean: true,
     // string-length is inlined so consumers don't need to install it as a runtime dep


### PR DESCRIPTION
## Summary

- Bump the package to `2.0.2` for a publishable patch release.
- Point package `types` and `exports["."].types` at the generated `dist/esm/index.d.mts` file.
- Emit the ESM bundle as `dist/esm/index.mjs` and point ESM metadata at it.
- Add a changelog entry for the metadata fix.

## Context

This fixes the broken TypeScript declarations found while updating Kibana Console to `@elastic/micro-jq@2.0.1`: https://github.com/elastic/kibana/pull/276928

`dist/` is a generated publish artifact, so `dist/esm/index.d.mts` is not present in the source tree before build. It is generated by `tsup` during `npm run build`, then included by `npm pack` / `npm publish` because package metadata includes `dist/esm` in the `files` list.

The published `2.0.1` tarball contains `dist/esm/index.d.mts`, but its `package.json` points both `types` and `exports["."].types` at `dist/esm/index.d.ts`. That metadata mismatch causes consumers to report `TS7016: Could not find a declaration file for module '@elastic/micro-jq'`.

## Validation

- `npm test`
- `node --input-type=module -e "import { executeScript } from '@elastic/micro-jq'; console.log(executeScript({ foo: 'bar' }, '.foo'))"`
- `node -e "const { executeScript } = require('@elastic/micro-jq'); console.log(executeScript({ foo: 'bar' }, '.foo'))"`
- `npm pack --dry-run --json`